### PR TITLE
HTML validation specs

### DIFF
--- a/spec/features/links_spec.rb
+++ b/spec/features/links_spec.rb
@@ -7,11 +7,42 @@ describe "The home page" do
 end
 
 describe "The home page" do
-  it "has at least three links", points: 3 do
+  it "has at least three `<a>` link elements", points: 3 do
     visit "/"
 
     a_count = all("a").count
     expect(a_count).to be >= 3,
-                       "Expected page to have at least three 'a' HTML link elements, but found #{a_count} instead."
+      "Expected page to have at least three `<a>` HTML link elements, but found #{a_count} instead."
+  end
+end
+
+describe "The home page" do
+  it "has the DOCTYPE declaration as the VERY FIRST line.", points: 1 do
+    visit "/"
+    
+    source_code = page.html
+    source_code_without_extra_spaces = source_code.strip
+    first_line = source_code_without_extra_spaces.split("\n").first
+    downcased_first_line = first_line.downcase
+    expect(first_line).to match(/<!doctype html>/i),
+      "Expected the first line of the HTML file to contain a doctype declaration. Found: #{first_line}"
+  end
+end
+
+describe "The home page" do
+  it "has a `<head>` section to make it a valid HTML document.", points: 1 do
+    visit "/"
+
+    expect(page).to have_tag("head", count: 1),
+      "Expected page to have a `<head>` HTML element to make it a valid HTML document."
+  end
+end
+
+describe "The home page" do
+  it "has a `<body>` section to make it a valid HTML document.", points: 1 do
+    visit "/"
+
+    expect(page).to have_tag("body", count: 1),
+      "Expected page to have a `<body>` HTML element to make it a valid HTML document."
   end
 end


### PR DESCRIPTION
Added some specs for `DOCTYPE`, `head`, and `body`. Better way would be [this ticket](https://linear.app/firstdraft/issue/FIR-398/html-validator-test-in-all-projects)